### PR TITLE
Fix for issue #8 - Out-of-bounds read of VIN buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX = g++
 
-CPPFLAGS = -g -Wall -Wextra -std=c++11
+CPPFLAGS = -g -Wall -Wextra -std=c++11 -fsanitize=address
 LDFLAGS = -shared
 TESTFLAGS = -g -L/usr/lib -lgtest -lgtest_main -lpthread
 

--- a/examples/exampleDoIPServer.cpp
+++ b/examples/exampleDoIPServer.cpp
@@ -97,7 +97,8 @@ void listenTcp() {
 }
 
 void ConfigureDoipServer() {
-
+    // VIN needs to have a fixed length of 17 bytes.
+    // Shorter VINs will be padded with '0'
     server.setVIN("FOOBAR");
     server.setLogicalGatewayAddress(LOGICAL_ADDRESS);
     server.setGID(0);

--- a/libdoipcommon/test/DoIPGenericHeaderHandler_Test.cpp
+++ b/libdoipcommon/test/DoIPGenericHeaderHandler_Test.cpp
@@ -24,6 +24,10 @@ class GenericHeaderTest : public ::testing::Test {
 			request[13] = 0x00;
 			request[14] = 0x00;
 		}
+
+		void TearDown() override {
+			delete[] request;
+		}
 };
 
 /*

--- a/libdoipserver/src/VehicleIdentificationHandler.cpp
+++ b/libdoipserver/src/VehicleIdentificationHandler.cpp
@@ -1,8 +1,6 @@
 #include "VehicleIdentificationHandler.h"
 #include <iostream>
 
-
-
 unsigned char* createVehicleIdentificationResponse(std::string VIN,unsigned short LogicalAddress, 
                                                     unsigned char* EID, unsigned char* GID,
                                                     unsigned char FurtherActionReq) //also used für the Vehicle Announcement
@@ -10,11 +8,16 @@ unsigned char* createVehicleIdentificationResponse(std::string VIN,unsigned shor
     unsigned char* message = createGenericHeader(PayloadType::VEHICLEIDENTRESPONSE, _VIResponseLength);
     
     //VIN Number 
-    int j = 0;
+    unsigned int j = 0;
     for(int i = 8; i <= 24; i++)
-    {      
-        message[i] = (unsigned char)VIN[j];
-        j++;
+    {
+        if (j < VIN.length()){
+            message[i] = (unsigned char)VIN[j];
+            j++;
+	} else {
+	    //Pad with zero if VIN is shorter than 16 bytes
+	    message[i] = 0;
+	}
     }
     
     //Logical Adress

--- a/libdoipserver/src/VehicleIdentificationHandler.cpp
+++ b/libdoipserver/src/VehicleIdentificationHandler.cpp
@@ -15,8 +15,8 @@ unsigned char* createVehicleIdentificationResponse(std::string VIN,unsigned shor
             message[i] = (unsigned char)VIN[j];
             j++;
 	} else {
-	    //Pad with zero if VIN is shorter than 16 bytes
-	    message[i] = 0;
+	    //Pad with ASCII '0' if VIN is shorter than 17 bytes
+	    message[i] = (unsigned char)'0';
 	}
     }
     

--- a/libdoipserver/test/RoutingActivationHandler_Test.cpp
+++ b/libdoipserver/test/RoutingActivationHandler_Test.cpp
@@ -25,6 +25,10 @@ class RoutingActivationTest : public ::testing::Test {
 			request[13] = 0x00;
 			request[14] = 0x00;
 		}
+
+		void TearDown() override {
+			delete[] request;
+		}
 };
 
 /*

--- a/libdoipserver/test/VehicleIdentificationHandler_Test.cpp
+++ b/libdoipserver/test/VehicleIdentificationHandler_Test.cpp
@@ -8,8 +8,9 @@ using namespace std;
 
 class VehicleIdentificationHandlerTest : public ::testing::Test {
 	public:
-		string matchingVIN = "MatchingVin_1234";
+		string matchingVIN = "MatchingVin_12345";
 		string shortVIN = "shortVin";
+		string shortVINPadded = "shortVin000000000";
 		unsigned char EID[6] = {0, 0, 0, 0, 0, 0};
 		unsigned char GID[6] = {0, 0, 0, 0, 0, 0};
 		unsigned char far = 0;
@@ -19,48 +20,49 @@ class VehicleIdentificationHandlerTest : public ::testing::Test {
 };
 
 /*
- * Checks if a VIN with 16 bytes matches correctly the input data
+ * Checks if a VIN with 17 bytes matches correctly the input data
  */
-TEST_F(VehicleIdentificationHandlerTest, Vin16Bytes) {
+TEST_F(VehicleIdentificationHandlerTest, Vin17Bytes) {
 	// Call function under test to create message
 	unsigned char * message = createVehicleIdentificationResponse(matchingVIN, 0, EID, GID, far);
 	
 	// Extract VIN from created test message
-	char tempvin[17]; // Need 1 byte more for \0 at the end for parsing via string()
-        for(int i=0; i<16; i++) {
+	char tempvin[18]; // Need 1 byte more for \0 at the end for parsing via string()
+        for(int i=0; i<=16; i++) {
 		tempvin[i] = message[i+8];
 	}
-	tempvin[16] = 0; // Mark end of string
+	tempvin[17] = 0; // Mark end of string
 	
 	delete[] message;
 	
 	// Assert that extracted VIN matches input data
 	string expected = string(tempvin);
-	EXPECT_EQ(matchingVIN, expected) << "Setting VIN with 16 bytes failed";
+	EXPECT_EQ(matchingVIN, expected) << "Setting VIN with 17 bytes failed";
 }
 
 /*
- * Checks if a VIN < 16 bytes is padded correctly with zero bytes
+ * Checks if a VIN < 17 bytes is padded correctly with zero bytes
  */
-TEST_F(VehicleIdentificationHandlerTest, VinLessThan16Bytes) {
+TEST_F(VehicleIdentificationHandlerTest, VinLessThan17Bytes) {
 	// Call function under test to create message
 	unsigned char * message = createVehicleIdentificationResponse(shortVIN, 0, EID, GID, far);
 	
 	// Extract VIN from created test message
-	char c_tempvin[16];
-        for(int i=0; i<16; i++) {
+	char c_tempvin[18];
+        for(int i=0; i<=16; i++) {
 		c_tempvin[i] = message[i+8];
 	}
+	c_tempvin[17] = 0; // Mark end of string
 
 	// Create expected string value
 	string actualVin = string(c_tempvin);
 
 	// Assert that extracted VIN matches input data
-	EXPECT_EQ(shortVIN, actualVin) << "Setting VIN with < 16 bytes failed";
+	EXPECT_EQ(shortVINPadded, actualVin) << "Setting VIN with < 17 bytes failed";
 	
-	// Assert message after shortVin bytes is padded with zeros
-	for(int i=16; i<24; i++) {
-		EXPECT_EQ(message[i], 0) << "VIN not correctly padded at byte: " << i;
+	// Assert message after shortVin bytes is padded with '0'
+	for(int i=16; i<=24; i++) {
+		EXPECT_EQ(message[i], '0') << "VIN not correctly padded at byte: " << i;
 	}
 	delete[] message;
 }

--- a/libdoipserver/test/VehicleIdentificationHandler_Test.cpp
+++ b/libdoipserver/test/VehicleIdentificationHandler_Test.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+#include "VehicleIdentificationHandler.h"
+#include <stdint.h>
+#include <string>
+#include "DoIPServer.h"
+
+using namespace std;
+
+class VehicleIdentificationHandlerTest : public ::testing::Test {
+	public:
+		string matchingVIN = "MatchingVin_1234";
+		string shortVIN = "shortVin";
+		unsigned char EID[6] = {0, 0, 0, 0, 0, 0};
+		unsigned char GID[6] = {0, 0, 0, 0, 0, 0};
+		unsigned char far = 0;
+	protected:
+		void SetUp() override {
+		}
+};
+
+/*
+ * Checks if a VIN with 16 bytes matches correctly the input data
+ */
+TEST_F(VehicleIdentificationHandlerTest, Vin16Bytes) {
+	// Call function under test to create message
+	unsigned char * message = createVehicleIdentificationResponse(matchingVIN, 0, EID, GID, far);
+	
+	// Extract VIN from created test message
+	char tempvin[17]; // Need 1 byte more for \0 at the end for parsing via string()
+        for(int i=0; i<16; i++) {
+		tempvin[i] = message[i+8];
+	}
+	tempvin[16] = 0; // Mark end of string
+	
+	delete[] message;
+	
+	// Assert that extracted VIN matches input data
+	string expected = string(tempvin);
+	EXPECT_EQ(matchingVIN, expected) << "Setting VIN with 16 bytes failed";
+}
+
+/*
+ * Checks if a VIN < 16 bytes is padded correctly with zero bytes
+ */
+TEST_F(VehicleIdentificationHandlerTest, VinLessThan16Bytes) {
+	// Call function under test to create message
+	unsigned char * message = createVehicleIdentificationResponse(shortVIN, 0, EID, GID, far);
+	
+	// Extract VIN from created test message
+	char c_tempvin[16];
+        for(int i=0; i<16; i++) {
+		c_tempvin[i] = message[i+8];
+	}
+
+	// Create expected string value
+	string actualVin = string(c_tempvin);
+
+	// Assert that extracted VIN matches input data
+	EXPECT_EQ(shortVIN, actualVin) << "Setting VIN with < 16 bytes failed";
+	
+	// Assert message after shortVin bytes is padded with zeros
+	for(int i=16; i<24; i++) {
+		EXPECT_EQ(message[i], 0) << "VIN not correctly padded at byte: " << i;
+	}
+	delete[] message;
+}
+


### PR DESCRIPTION
See issue #8 for bug report.

The fix checks the VIN length and adds padding of '0' characters in case the VIN value is shorter than 17 bytes.
Added unit tests for the padding code as well.

Additionally enabled ASan in the Makefile and fixed two further memleaks in other tests.